### PR TITLE
hostapp-update-hooks: Fix bootloader hook

### DIFF
--- a/layers/meta-balena-nanopc-t4/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
+++ b/layers/meta-balena-nanopc-t4/recipes-support/hostapp-update-hooks/files/99-flash-bootloader
@@ -22,7 +22,8 @@ uboot_seek_blocks=16384
 
 device="/dev/"$(findmnt --noheadings --canonicalize --output SOURCE /mnt/boot/ | xargs lsblk -no pkname)
 
-update_files="idbloader trust uboot"
+# we sort the update files list by ascending memory addresses these binaries will be written to
+update_files="idbloader uboot trust"
 
 for i in $update_files; do
 	current_update_file=$(eval echo \$${i}_file)
@@ -39,7 +40,10 @@ for i in $update_files; do
 	# calculate md5sum of the data already written to $device, using $update_size bytes and skipping $skip_bytes from $device
 	existing_md5sum=$(dd if=$device skip=$skip_bytes bs=1 count=$update_size status=none | md5sum | awk '{print $1}')
 
-	if [ ! "$existing_md5sum" = "$update_md5sum" ]; then
+	if [ ! "$existing_md5sum" = "$update_md5sum" ] || [ -n "$force_write" ]; then
+		# we are flashing a binary and let's signal that we need to also flash the remaining binaries
+		# (if we do not write the remaining binaries when the previous one was written then the board will not boot anymore, due to the nature of the secure boot mechanism on the NanoPC T4)
+		force_write=true
 		echo "Flashing $current_update_file to $device"
 		dd if=/resin-boot/$current_update_file of=$device conv=fdatasync seek=$seek_blocks bs=$block_size
 	fi


### PR DESCRIPTION
The nature of the secure boot on the NanoPC T4 requires us to write
all the remaining boot binaries in case one of them was written to the
eMMC.

Changelog-entry: Fix bootloader hostOS update hook
Signed-off-by: Florin Sarbu <florin@balena.io>