### PR TITLE
linux_rockchip_%.bbappend: Add NFLX-2019-001 series of patches

### DIFF
--- a/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0002-NFLX-2019-001-SACK-Panic.patch
+++ b/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0002-NFLX-2019-001-SACK-Panic.patch
@@ -1,0 +1,155 @@
+Date: Sat,  8 Jun 2019 10:38:05 -0700
+Subject: [PATCH net 1/4] tcp: limit payload size of sacked skbs
+From: Eric Dumazet <edumazet@google.com>
+
+Jonathan Looney reported that TCP can trigger the following crash
+in tcp_shifted_skb() :
+
+    BUG_ON(tcp_skb_pcount(skb) < pcount);
+
+This can happen if the remote peer has advertized the smallest
+MSS that linux TCP accepts : 48
+
+An skb can hold 17 fragments, and each fragment can hold 32KB
+on x86, or 64KB on PowerPC.
+
+This means that the 16bit witdh of TCP_SKB_CB(skb)->tcp_gso_segs
+can overflow.
+
+Note that tcp_sendmsg() builds skbs with less than 64KB
+of payload, so this problem needs SACK to be enabled.
+SACK blocks allow TCP to coalesce multiple skbs in the retransmit
+queue, thus filling the 17 fragments to maximal capacity.
+
+Fixes: 832d11c5cd07 ("tcp: Try to restore large SKBs while SACK processing")
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Reviewed-by: Tyler Hicks <tyhicks@canonical.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ include/linux/tcp.h   |  3 +++
+ include/net/tcp.h     |  2 ++
+ net/ipv4/tcp.c        |  1 +
+ net/ipv4/tcp_input.c  | 26 ++++++++++++++++++++------
+ net/ipv4/tcp_output.c |  4 ++--
+ 5 files changed, 28 insertions(+), 8 deletions(-)
+
+diff --git a/include/linux/tcp.h b/include/linux/tcp.h
+index b386361..cfbe3c4 100644
+--- a/include/linux/tcp.h
++++ b/include/linux/tcp.h
+@@ -410,4 +410,7 @@ static inline void tcp_saved_syn_free(struct tcp_sock *tp)
+ 	tp->saved_syn = NULL;
+ }
+ 
++int tcp_skb_shift(struct sk_buff *to, struct sk_buff *from, int pcount,
++		  int shiftlen);
++
+ #endif	/* _LINUX_TCP_H */
+diff --git a/include/net/tcp.h b/include/net/tcp.h
+index 4ea3739..03c6f68 100644
+--- a/include/net/tcp.h
++++ b/include/net/tcp.h
+@@ -54,6 +54,8 @@ void tcp_time_wait(struct sock *sk, int state, int timeo);
+ 
+ #define MAX_TCP_HEADER	(128 + MAX_HEADER)
+ #define MAX_TCP_OPTION_SPACE 40
++#define TCP_MIN_SND_MSS		48
++#define TCP_MIN_GSO_SIZE	(TCP_MIN_SND_MSS - MAX_TCP_OPTION_SPACE)
+ 
+ /*
+  * Never offer a window over 32767 without using window scaling. Some
+diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
+index dd2a41b..367dc51 100644
+--- a/net/ipv4/tcp.c
++++ b/net/ipv4/tcp.c
+@@ -3170,6 +3170,7 @@ void __init tcp_init(void)
+ 	int max_rshare, max_wshare, cnt;
+ 	unsigned int i;
+ 
++	BUILD_BUG_ON(TCP_MIN_SND_MSS <= MAX_TCP_OPTION_SPACE);
+ 	sock_skb_cb_check_size(sizeof(struct tcp_skb_cb));
+ 
+ 	percpu_counter_init(&tcp_sockets_allocated, 0, GFP_KERNEL);
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index 35e97ff..467d414 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -1267,7 +1267,7 @@ static bool tcp_shifted_skb(struct sock *sk, struct sk_buff *skb,
+ 	TCP_SKB_CB(skb)->seq += shifted;
+ 
+ 	tcp_skb_pcount_add(prev, pcount);
+-	BUG_ON(tcp_skb_pcount(skb) < pcount);
++	WARN_ON_ONCE(tcp_skb_pcount(skb) < pcount);
+ 	tcp_skb_pcount_add(skb, -pcount);
+ 
+ 	/* When we're adding to gso_segs == 1, gso_size will be zero,
+@@ -1329,6 +1329,21 @@ static int skb_can_shift(const struct sk_buff *skb)
+ 	return !skb_headlen(skb) && skb_is_nonlinear(skb);
+ }
+ 
++int tcp_skb_shift(struct sk_buff *to, struct sk_buff *from,
++		  int pcount, int shiftlen)
++{
++	/* TCP min gso_size is 8 bytes (TCP_MIN_GSO_SIZE)
++	 * Since TCP_SKB_CB(skb)->tcp_gso_segs is 16 bits, we need
++	 * to make sure not storing more than 65535 * 8 bytes per skb,
++	 * even if current MSS is bigger.
++	 */
++	if (unlikely(to->len + shiftlen >= 65535 * TCP_MIN_GSO_SIZE))
++		return 0;
++	if (unlikely(tcp_skb_pcount(to) + pcount > 65535))
++		return 0;
++	return skb_shift(to, from, shiftlen);
++}
++
+ /* Try collapsing SACK blocks spanning across multiple skbs to a single
+  * skb.
+  */
+@@ -1434,7 +1449,7 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 	if (!after(TCP_SKB_CB(skb)->seq + len, tp->snd_una))
+ 		goto fallback;
+ 
+-	if (!skb_shift(prev, skb, len))
++	if (!tcp_skb_shift(prev, skb, pcount, len))
+ 		goto fallback;
+ 	if (!tcp_shifted_skb(sk, skb, state, pcount, len, mss, dup_sack))
+ 		goto out;
+@@ -1453,10 +1468,9 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 		goto out;
+ 
+ 	len = skb->len;
+-	if (skb_shift(prev, skb, len)) {
+-		pcount += tcp_skb_pcount(skb);
+-		tcp_shifted_skb(sk, skb, state, tcp_skb_pcount(skb), len, mss, 0);
+-	}
++	pcount = tcp_skb_pcount(skb);
++	if (tcp_skb_shift(prev, skb, pcount, len))
++		tcp_shifted_skb(sk, skb, state, pcount, len, mss, 0);
+ 
+ out:
+ 	state->fack_count += pcount;
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index 3e52a48..34042e0 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1337,8 +1337,8 @@ static inline int __tcp_mtu_to_mss(struct sock *sk, int pmtu)
+ 	mss_now -= icsk->icsk_ext_hdr_len;
+ 
+ 	/* Then reserve room for full set of TCP options and 8 bytes of data */
+-	if (mss_now < 48)
+-		mss_now = 48;
++	if (mss_now < TCP_MIN_SND_MSS)
++		mss_now = TCP_MIN_SND_MSS;
+ 	return mss_now;
+ }
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0003-NFLX-2019-001-SACK-Panic-for-lteq-4.14.patch
+++ b/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0003-NFLX-2019-001-SACK-Panic-for-lteq-4.14.patch
@@ -1,0 +1,62 @@
+From cd4ffa93f16efea290bb70537f98f518e1927e63 Mon Sep 17 00:00:00 2001
+From: Joao Martins <joao.m.martins@oracle.com>
+Date: Mon, 10 Jun 2019 23:12:39 +0100
+Subject: [PATCH 5/5] tcp: fix fack_count accounting on tcp_shift_skb_data()
+
+v4.15 or since commit 737ff314563 ("tcp: use sequence distance to
+detect reordering") had switched from the packet-based FACK tracking
+to sequence-based.
+
+v4.14 and older still have the old logic and hence on
+tcp_skb_shift_data() needs to retain its original logic and have
+@fack_count in sync. In other words, we keep the increment of pcount with
+tcp_skb_pcount(skb) to later used that to update fack_count. To make it
+more explicit we track the new skb that gets incremented to pcount in
+@next_pcount, and we get to avoid the constant invocation of
+tcp_skb_pcount(skb) all together.
+
+Fixes: a5f1faa40101 ("tcp: limit payload size of sacked skbs")
+Reported-by: Alexey Kodanev <alexey.kodanev@oracle.com>
+Reviewed-by: Jack Vogel <jack.vogel@oracle.com>
+Reviewed-by: John Haxby <john.haxby@oracle.com>
+Reviewed-by: Rao Shoaib rao.shoaib@oracle.com>
+Signed-off-by: Joao Martins <joao.m.martins@oracle.com>
+Signed-off-by: Konrad Rzeszutek Wilk <konrad.wilk@oracle.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ net/ipv4/tcp_input.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index c092c7c..6c7190c 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -1422,6 +1422,7 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 	struct tcp_sock *tp = tcp_sk(sk);
+ 	struct sk_buff *prev;
+ 	int mss;
++	int next_pcount;
+ 	int pcount = 0;
+ 	int len;
+ 	int in_sack;
+@@ -1538,10 +1539,11 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 		goto out;
+ 
+ 	len = skb->len;
+-	pcount = tcp_skb_pcount(skb);
+-	if (tcp_skb_shift(prev, skb, pcount, len))
+-		tcp_shifted_skb(sk, skb, state, pcount, len, mss, 0);
+-
++	next_pcount = tcp_skb_pcount(skb);
++	if (tcp_skb_shift(prev, skb, next_pcount, len)) {
++		pcount += next_pcount;
++		tcp_shifted_skb(sk, skb, state, next_pcount, len, mss, 0);
++	}
+ out:
+ 	state->fack_count += pcount;
+ 	return prev;
+-- 
+2.7.4
+

--- a/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0004-NFLX-2019-001-SACK-Slowness.patch
+++ b/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0004-NFLX-2019-001-SACK-Slowness.patch
@@ -1,0 +1,77 @@
+Date: Sat,  8 Jun 2019 10:38:06 -0700
+Subject: [PATCH net 2/4] tcp: tcp_fragment() should apply sane memory limits
+From: Eric Dumazet <edumazet@google.com>
+
+Jonathan Looney reported that a malicious peer can force a sender
+to fragment its retransmit queue into tiny skbs, inflating memory
+usage and/or overflow 32bit counters.
+
+TCP allows an application to queue up to sk_sndbuf bytes,
+so we need to give some allowance for non malicious splitting
+of retransmit queue.
+
+A new SNMP counter is added to monitor how many times TCP
+did not allow to split an skb if the allowance was exceeded.
+
+Note that this counter might increase in the case applications
+use SO_SNDBUF socket option to lower sk_sndbuf.
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Acked-by: Yuchung Cheng <ycheng@google.com>
+Reviewed-by: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ include/uapi/linux/snmp.h | 1 +
+ net/ipv4/proc.c           | 1 +
+ net/ipv4/tcp_output.c     | 5 +++++
+ 3 files changed, 7 insertions(+)
+
+diff --git a/include/uapi/linux/snmp.h b/include/uapi/linux/snmp.h
+index f5d753e..bf31965 100644
+--- a/include/uapi/linux/snmp.h
++++ b/include/uapi/linux/snmp.h
+@@ -278,6 +278,7 @@ enum
+ 	LINUX_MIB_TCPKEEPALIVE,			/* TCPKeepAlive */
+ 	LINUX_MIB_TCPMTUPFAIL,			/* TCPMTUPFail */
+ 	LINUX_MIB_TCPMTUPSUCCESS,		/* TCPMTUPSuccess */
++	LINUX_MIB_TCPWQUEUETOOBIG,		/* TCPWqueueTooBig */
+ 	__LINUX_MIB_MAX
+ };
+ 
+diff --git a/net/ipv4/proc.c b/net/ipv4/proc.c
+index 3fbf688..88aaf14 100644
+--- a/net/ipv4/proc.c
++++ b/net/ipv4/proc.c
+@@ -299,6 +299,7 @@ static const struct snmp_mib snmp4_net_list[] = {
+ 	SNMP_MIB_ITEM("TCPKeepAlive", LINUX_MIB_TCPKEEPALIVE),
+ 	SNMP_MIB_ITEM("TCPMTUPFail", LINUX_MIB_TCPMTUPFAIL),
+ 	SNMP_MIB_ITEM("TCPMTUPSuccess", LINUX_MIB_TCPMTUPSUCCESS),
++	SNMP_MIB_ITEM("TCPWqueueTooBig", LINUX_MIB_TCPWQUEUETOOBIG),
+ 	SNMP_MIB_SENTINEL
+ };
+ 
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index def09d1..36d1945 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1274,6 +1274,11 @@ int tcp_fragment(struct sock *sk, struct sk_buff *skb, u32 len,
+ 	if (nsize < 0)
+ 		nsize = 0;
+ 
++	if (unlikely((sk->sk_wmem_queued >> 1) > sk->sk_sndbuf)) {
++		NET_INC_STATS(sock_net(sk), LINUX_MIB_TCPWQUEUETOOBIG);
++		return -ENOMEM;
++	}
++
+ 	if (skb_unclone(skb, gfp))
+ 		return -ENOMEM;
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch
+++ b/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch
@@ -1,0 +1,134 @@
+Date: Sat,  8 Jun 2019 10:38:07 -0700
+Subject: [PATCH net 3/4] tcp: add tcp_min_snd_mss sysctl
+From: Eric Dumazet <edumazet@google.com>
+
+Some TCP peers announce a very small MSS option in their SYN and/or
+SYN/ACK messages.
+
+This forces the stack to send packets with a very high network/cpu
+overhead.
+
+Linux has enforced a minimal value of 48. Since this value includes
+the size of TCP options, and that the options can consume up to 40
+bytes, this means that each segment can include only 8 bytes of payload.
+
+In some cases, it can be useful to increase the minimal value
+to a saner value.
+
+We still let the default to 48 (TCP_MIN_SND_MSS), for compatibility
+reasons.
+
+Note that TCP_MAXSEG socket option enforces a minimal value
+of (TCP_MIN_MSS). David Miller increased this minimal value
+in commit c39508d6f118 ("tcp: Make TCP_MAXSEG minimum more correct.")
+from 64 to 88.
+
+We might in the future merge TCP_MIN_SND_MSS and TCP_MIN_MSS.
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Suggested-by: Jonathan Looney <jtl@netflix.com>
+Cc: Neal Cardwell <ncardwell@google.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ Documentation/networking/ip-sysctl.txt |  8 ++++++++
+ include/net/netns/ipv4.h               |  1 +
+ net/ipv4/sysctl_net_ipv4.c             | 11 +++++++++++
+ net/ipv4/tcp_ipv4.c                    |  1 +
+ net/ipv4/tcp_output.c                  |  3 +--
+ 5 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/networking/ip-sysctl.txt b/Documentation/networking/ip-sysctl.txt
+index 3db8c67..2a5d3c3 100644
+--- a/Documentation/networking/ip-sysctl.txt
++++ b/Documentation/networking/ip-sysctl.txt
+@@ -233,6 +233,14 @@ tcp_base_mss - INTEGER
+ 	Path MTU discovery (MTU probing).  If MTU probing is enabled,
+ 	this is the initial MSS used by the connection.
+ 
++tcp_min_snd_mss - INTEGER
++	TCP SYN and SYNACK messages usually advertise an ADVMSS option,
++	as described in RFC 1122 and RFC 6691.
++	If this ADVMSS option is smaller than tcp_min_snd_mss,
++	it is silently capped to tcp_min_snd_mss.
++
++	Default : 48 (at least 8 bytes of payload per segment)
++
+ tcp_congestion_control - STRING
+ 	Set the congestion control algorithm to be used for new
+ 	connections. The algorithm "reno" is always available, but
+diff --git a/include/net/netns/ipv4.h b/include/net/netns/ipv4.h
+index d3fd5c3..d57476e 100644
+--- a/include/net/netns/ipv4.h
++++ b/include/net/netns/ipv4.h
+@@ -95,6 +95,7 @@ struct netns_ipv4 {
+ #endif
+ 	int sysctl_tcp_mtu_probing;
+ 	int sysctl_tcp_base_mss;
++	int sysctl_tcp_min_snd_mss;
+ 	int sysctl_tcp_probe_threshold;
+ 	u32 sysctl_tcp_probe_interval;
+ 
+diff --git a/net/ipv4/sysctl_net_ipv4.c b/net/ipv4/sysctl_net_ipv4.c
+index 4b8551d..2078ec0 100644
+--- a/net/ipv4/sysctl_net_ipv4.c
++++ b/net/ipv4/sysctl_net_ipv4.c
+@@ -35,6 +35,8 @@ static int ip_local_port_range_min[] = { 1, 1 };
+ static int ip_local_port_range_max[] = { 65535, 65535 };
+ static int tcp_adv_win_scale_min = -31;
+ static int tcp_adv_win_scale_max = 31;
++static int tcp_min_snd_mss_min = TCP_MIN_SND_MSS;
++static int tcp_min_snd_mss_max = 65535;
+ static int ip_ttl_min = 1;
+ static int ip_ttl_max = 255;
+ static int tcp_syn_retries_min = 1;
+@@ -834,6 +836,15 @@ static struct ctl_table ipv4_net_table[] = {
+ 		.proc_handler	= proc_dointvec,
+ 	},
+ 	{
++		.procname	= "tcp_min_snd_mss",
++		.data		= &init_net.ipv4.sysctl_tcp_min_snd_mss,
++		.maxlen		= sizeof(int),
++		.mode		= 0644,
++		.proc_handler	= proc_dointvec_minmax,
++		.extra1		= &tcp_min_snd_mss_min,
++		.extra2		= &tcp_min_snd_mss_max,
++	},
++	{
+ 		.procname	= "tcp_probe_threshold",
+ 		.data		= &init_net.ipv4.sysctl_tcp_probe_threshold,
+ 		.maxlen		= sizeof(int),
+diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
+index 1769939..47d4441 100644
+--- a/net/ipv4/tcp_ipv4.c
++++ b/net/ipv4/tcp_ipv4.c
+@@ -2450,6 +2450,7 @@ static int __net_init tcp_sk_init(struct net *net)
+ 	net->ipv4.sysctl_tcp_ecn_fallback = 1;
+ 
+ 	net->ipv4.sysctl_tcp_base_mss = TCP_BASE_MSS;
++	net->ipv4.sysctl_tcp_min_snd_mss = TCP_MIN_SND_MSS;
+ 	net->ipv4.sysctl_tcp_probe_threshold = TCP_PROBE_THRESHOLD;
+ 	net->ipv4.sysctl_tcp_probe_interval = TCP_PROBE_INTERVAL;
+ 
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index caf2c23..95f90a1 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1348,8 +1348,7 @@ static inline int __tcp_mtu_to_mss(struct sock *sk, int pmtu)
+ 	mss_now -= icsk->icsk_ext_hdr_len;
+ 
+ 	/* Then reserve room for full set of TCP options and 8 bytes of data */
+-	if (mss_now < TCP_MIN_SND_MSS)
+-		mss_now = TCP_MIN_SND_MSS;
++	mss_now = max(mss_now, sock_net(sk)->ipv4.sysctl_tcp_min_snd_mss);
+ 	return mss_now;
+ }
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch
+++ b/layers/meta-balena-nanopc-t4/recipes-kernel/linux/files/0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch
@@ -1,0 +1,39 @@
+Date: Sat,  8 Jun 2019 10:38:08 -0700
+Subject: [PATCH net 4/4] tcp: enforce tcp_min_snd_mss in tcp_mtu_probing()
+From: Eric Dumazet <edumazet@google.com>
+
+If mtu probing is enabled tcp_mtu_probing() could very well end up
+with a too small MSS.
+
+Use the new sysctl tcp_min_snd_mss to make sure MSS search
+is performed in an acceptable range.
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Lemon <jonathan.lemon@gmail.com>
+Cc: Jonathan Looney <jtl@netflix.com>
+Cc: Neal Cardwell <ncardwell@google.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ net/ipv4/tcp_timer.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/net/ipv4/tcp_timer.c b/net/ipv4/tcp_timer.c
+index a845b76..592d6e9 100644
+--- a/net/ipv4/tcp_timer.c
++++ b/net/ipv4/tcp_timer.c
+@@ -141,6 +141,7 @@ static void tcp_mtu_probing(struct inet_connection_sock *icsk, struct sock *sk)
+ 			mss = tcp_mtu_to_mss(sk, icsk->icsk_mtup.search_low) >> 1;
+ 			mss = min(net->ipv4.sysctl_tcp_base_mss, mss);
+ 			mss = max(mss, 68 - tp->tcp_header_len);
++			mss = max(mss, net->ipv4.sysctl_tcp_min_snd_mss);
+ 			icsk->icsk_mtup.search_low = tcp_mss_to_mtu(sk, mss);
+ 			tcp_sync_mss(sk, icsk->icsk_pmtu_cookie);
+ 		}
+-- 
+2.7.4
+

--- a/layers/meta-balena-nanopc-t4/recipes-kernel/linux/linux-rockchip_%.bbappend
+++ b/layers/meta-balena-nanopc-t4/recipes-kernel/linux/linux-rockchip_%.bbappend
@@ -1,1 +1,10 @@
 inherit kernel-resin
+
+FILESEXTRAPATHS_append := ":${THISDIR}/files"
+SRC_URI_append = " \
+        file://0002-NFLX-2019-001-SACK-Panic.patch \
+        file://0003-NFLX-2019-001-SACK-Panic-for-lteq-4.14.patch \
+        file://0004-NFLX-2019-001-SACK-Slowness.patch \
+        file://0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
+        file://0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
+"


### PR DESCRIPTION
Add patches for multiple TCP-based remote denial
of service vulnerabilities identified by Netflix.
Patch source:
https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-001.md

Changelog-entry: Patches for TCP-based remote denial of service vulnerabilities
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>