### PR TITLE
nanopc-t4.coffee: Set private to false for the public device types

### DIFF
--- a/nanopc-t4.coffee
+++ b/nanopc-t4.coffee
@@ -13,6 +13,7 @@ module.exports =
 	name: 'NanoPC-T4'
 	arch: 'aarch64'
 	state: 'new'
+	private: false
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Changelog-entry: Set private to false in .coffee files for the public device types
Signed-off-by: Florin Sarbu <florin@balena.io>